### PR TITLE
refactor(web): rebrand project from Student Manager to fastapi-nextjs-template

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -20,8 +20,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Student Manager",
-  description: "基于 Next.js 与 FastAPI 的学生管理系统模板",
+  title: "fastapi-nextjs-template",
+  description: "基于 Next.js 与 FastAPI 的全栈模板",
 };
 
 export default async function RootLayout({

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -10,6 +10,27 @@ export default function HomePage() {
       <h1 className="text-3xl font-semibold sm:text-4xl">{t("title")}</h1>
       <p className="text-lg text-muted-foreground">{t("subtitle")}</p>
       <p className="text-base leading-7 text-muted-foreground">{t("description")}</p>
+      <section className="mt-2">
+        <h2 className="text-xl font-medium">{t("stack.title")}</h2>
+        <ul className="mt-3 grid gap-2 text-sm text-muted-foreground sm:grid-cols-2">
+          <li>
+            <span className="font-medium text-foreground">{t("stack.backend.label")}: </span>
+            {t("stack.backend.value")}
+          </li>
+          <li>
+            <span className="font-medium text-foreground">{t("stack.frontend.label")}: </span>
+            {t("stack.frontend.value")}
+          </li>
+          <li>
+            <span className="font-medium text-foreground">{t("stack.database.label")}: </span>
+            {t("stack.database.value")}
+          </li>
+          <li>
+            <span className="font-medium text-foreground">{t("stack.devops.label")}: </span>
+            {t("stack.devops.value")}
+          </li>
+        </ul>
+      </section>
     </div>
   );
 }

--- a/web/src/i18n/messages/en/common.json
+++ b/web/src/i18n/messages/en/common.json
@@ -2,10 +2,10 @@
   "nav": {
     "home": "Home",
     "students": "Students",
-    "siteName": "Student Manager"
+    "siteName": "fastapi-nextjs-template"
   },
   "footer": {
-    "copyright": "© {year} Student Manager",
+    "copyright": "© {year} fastapi-nextjs-template",
     "poweredBy": "Powered by Next.js · FastAPI · shadcn/ui"
   },
   "common": {

--- a/web/src/i18n/messages/en/home.json
+++ b/web/src/i18n/messages/en/home.json
@@ -1,5 +1,12 @@
 {
-  "title": "Student Management System Template",
-  "subtitle": "A Next.js + FastAPI full-stack example, perfect for teaching and project starter.",
-  "description": "Navigate to the student management page through the navigation bar to experience basic query, pagination, and form submission features."
+  "title": "fastapi-nextjs-template",
+  "subtitle": "A full-stack template built with Next.js and FastAPI, ready to use.",
+  "description": "Includes a Students demo covering query, pagination and create form; integrates App Router, i18n and UI components. Built-in linting and API tests, AI-friendly development. Use the navigation above to explore.",
+  "stack": {
+    "title": "Tech Stack",
+    "backend": { "label": "Backend", "value": "FastAPI · SQLAlchemy 2 · Pydantic v2" },
+    "frontend": { "label": "Frontend", "value": "Next.js 16 · React 19 · TypeScript 5 · Tailwind CSS 4 · shadcn/ui · next-intl" },
+    "database": { "label": "Database", "value": "PostgreSQL" },
+    "devops": { "label": "Engineering", "value": "Docker Compose · Nginx reverse proxy · ESLint · Ruff · Pytest · GitHub Actions" }
+  }
 }

--- a/web/src/i18n/messages/zh/common.json
+++ b/web/src/i18n/messages/zh/common.json
@@ -2,10 +2,10 @@
   "nav": {
     "home": "首页",
     "students": "学生管理",
-    "siteName": "Student Manager"
+    "siteName": "fastapi-nextjs-template"
   },
   "footer": {
-    "copyright": "© {year} Student Manager",
+    "copyright": "© {year} fastapi-nextjs-template",
     "poweredBy": "Powered by Next.js · FastAPI · shadcn/ui"
   },
   "common": {

--- a/web/src/i18n/messages/zh/home.json
+++ b/web/src/i18n/messages/zh/home.json
@@ -1,5 +1,12 @@
 {
-  "title": "学生管理系统模板",
-  "subtitle": "Next.js + FastAPI 前后端分离示例,适合作为教学与项目起点。",
-  "description": "通过导航栏进入学生管理页面,体验查询、分页与新增表单的基础能力。"
+  "title": "fastapi-nextjs-template",
+  "subtitle": "一个基于 Next.js 与 FastAPI 的全栈模板，开箱即用。",
+  "description": "内置「学生管理」示例，涵盖查询、分页与表单新增；集成 App Router、国际化与 UI 组件。内置格式检查与接口测试工作流，AI 开发友好。通过上方导航进入示例页面体验。",
+  "stack": {
+    "title": "技术栈",
+    "backend": { "label": "后端", "value": "FastAPI · SQLAlchemy 2 · Pydantic v2" },
+    "frontend": { "label": "前端", "value": "Next.js 16 · React 19 · TypeScript 5 · Tailwind CSS 4 · shadcn/ui · next-intl" },
+    "database": { "label": "数据库", "value": "PostgreSQL" },
+    "devops": { "label": "工程化", "value": "Docker Compose · Nginx 反向代理 · ESLint · Ruff · Pytest · GitHub Actions" }
+  }
 }


### PR DESCRIPTION
## Summary
Rebrand the project from "Student Manager" to "fastapi-nextjs-template" to better reflect its purpose as a general-purpose full-stack template.

## Changes
- Update metadata title and description in layout.tsx
- Add comprehensive tech stack section to homepage
- Update i18n messages to reflect new branding
- Change site name from "Student Manager" to "fastapi-nextjs-template"
- Update both English and Chinese translations with detailed technology information

## Test plan
- [x] Verify homepage displays new branding correctly
- [x] Check that tech stack section shows all technologies
- [x] Confirm internationalization works in both languages
- [x] Ensure navigation and footer display correct site name

🤖 Generated with [Claude Code](https://claude.com/claude-code)