### PR TITLE
feat(api): add user seeding utility for development and testing environments

### DIFF
--- a/api/tests/unit_tests/test_security.py
+++ b/api/tests/unit_tests/test_security.py
@@ -16,7 +16,7 @@ def test_random_salt_hashes_differ() -> None:
     plain = "repeatable"
     h1 = hash_password(plain)
     h2 = hash_password(plain)
-    # bcrypt 含随机盐：同一明文两次哈希不应相等
+    # Argon2 含随机盐：同一明文两次哈希不应相等
     assert h1 != h2
     # 两个哈希均可被各自验证通过
     assert verify_password(plain, h1) is True

--- a/api/tests/unit_tests/test_security.py
+++ b/api/tests/unit_tests/test_security.py
@@ -13,6 +13,11 @@ def test_hash_and_verify() -> None:
 
 
 def test_random_salt_hashes_differ() -> None:
+    """
+    Ensure hashing the same password twice produces different hashes and both verify correctly.
+    
+    Verifies that hashes generated from identical plaintext differ (due to random salt) and that each generated hash validates successfully against the original plaintext.
+    """
     plain = "repeatable"
     h1 = hash_password(plain)
     h2 = hash_password(plain)

--- a/api/tests/unit_tests/test_seed_users.py
+++ b/api/tests/unit_tests/test_seed_users.py
@@ -25,6 +25,11 @@ def test_seed_creates_admin_and_user(db_session):
 
 
 def test_seed_idempotent_skips_when_no_change(db_session):
+    """
+    Verifies that calling upsert_user again with identical username, password, and role is idempotent and preserves the stored password hash.
+    
+    Creates an "admin" user, records its password hash, runs upsert_user with the same credentials a second time, and asserts that the operation reports "skipped" and the user's password_hash remains unchanged.
+    """
     upsert_user(db_session, "admin", "123456", "admin")
     db_session.commit()
     before = db_session.query(User).filter(User.username == "admin").one()
@@ -39,6 +44,11 @@ def test_seed_idempotent_skips_when_no_change(db_session):
 
 
 def test_seed_resets_lock_and_failures(db_session):
+    """
+    Verifies that upsert_user clears failed login attempts and lock state when updating an existing account.
+    
+    Creates a user, simulates a locked/failed-login state by setting `failed_login_attempts` and `lock_until`, calls `upsert_user` with the same credentials, and asserts the operation reports `"updated"` and that `failed_login_attempts` is reset to 0 and `lock_until` is cleared.
+    """
     user, _ = upsert_user(db_session, "user", "123456", "user")
     db_session.commit()
 

--- a/api/tests/unit_tests/test_seed_users.py
+++ b/api/tests/unit_tests/test_seed_users.py
@@ -1,0 +1,68 @@
+from datetime import UTC, datetime, timedelta
+
+from models.users import User
+from utils.security import verify_password
+from utils.seed_users import upsert_user
+
+
+def test_seed_creates_admin_and_user(db_session):
+    user_admin, action_admin = upsert_user(db_session, "admin", "123456", "admin")
+    user_user, action_user = upsert_user(db_session, "user", "123456", "user")
+    db_session.commit()
+
+    assert action_admin == "created"
+    assert action_user == "created"
+
+    got_admin = db_session.query(User).filter(User.username == "admin").one()
+    got_user = db_session.query(User).filter(User.username == "user").one()
+
+    assert got_admin.role == "admin"
+    assert got_user.role == "user"
+    assert got_admin.is_active is True
+    assert got_user.is_active is True
+    assert verify_password("123456", got_admin.password_hash) is True
+    assert verify_password("123456", got_user.password_hash) is True
+
+
+def test_seed_idempotent_skips_when_no_change(db_session):
+    upsert_user(db_session, "admin", "123456", "admin")
+    db_session.commit()
+    before = db_session.query(User).filter(User.username == "admin").one()
+    hash_before = before.password_hash
+
+    _, action = upsert_user(db_session, "admin", "123456", "admin")
+    db_session.commit()
+
+    after = db_session.query(User).filter(User.username == "admin").one()
+    assert action == "skipped"
+    assert after.password_hash == hash_before
+
+
+def test_seed_resets_lock_and_failures(db_session):
+    user, _ = upsert_user(db_session, "user", "123456", "user")
+    db_session.commit()
+
+    # 模拟锁定与失败计数
+    user.failed_login_attempts = 5
+    user.lock_until = datetime.now(UTC) + timedelta(hours=1)
+    db_session.commit()
+
+    _, action = upsert_user(db_session, "user", "123456", "user")
+    db_session.commit()
+
+    got = db_session.query(User).filter(User.username == "user").one()
+    assert action == "updated"
+    assert got.failed_login_attempts == 0
+    assert got.lock_until is None
+
+
+def test_seed_updates_role(db_session):
+    upsert_user(db_session, "bob", "123456", "user")
+    db_session.commit()
+
+    _, action = upsert_user(db_session, "bob", "123456", "admin")
+    db_session.commit()
+
+    got = db_session.query(User).filter(User.username == "bob").one()
+    assert action == "updated"
+    assert got.role == "admin"

--- a/api/utils/seed_users.py
+++ b/api/utils/seed_users.py
@@ -42,7 +42,7 @@ def upsert_user(session: Session, username: str, plain_password: str, role: str)
         need_update = True
 
     # 密码（若不匹配，则重置为指定默认密码）
-    if not verify_password("123456" if username in {"admin", "user"} else plain_password, user.password_hash):
+    if not verify_password(plain_password, user.password_hash):
         user.password_hash = hash_password(plain_password)
         need_update = True
 

--- a/api/utils/seed_users.py
+++ b/api/utils/seed_users.py
@@ -1,0 +1,97 @@
+# 使用方法: python -m utils.seed_users
+
+from __future__ import annotations
+
+import os
+
+from sqlalchemy.orm import Session
+
+from models.base import Base
+from models.users import User
+from utils.db import SessionLocal, engine
+from utils.logging import get_logger, init_logging
+from utils.security import hash_password, verify_password
+
+
+def ensure_tables() -> None:
+    """确保需要的表已创建(dev/test 便捷使用)."""
+    Base.metadata.create_all(bind=engine)
+
+
+def upsert_user(session: Session, username: str, plain_password: str, role: str) -> tuple[User, str]:
+    """插入或更新用户，返回 (user, action). action ∈ {created, updated, skipped}."""
+    user = session.query(User).filter_by(username=username).one_or_none()
+    if user is None:
+        user = User(
+            username=username,
+            password_hash=hash_password(plain_password),
+            role=role,
+            is_active=True,
+            token_version=1,
+            failed_login_attempts=0,
+            lock_until=None,
+        )
+        session.add(user)
+        return user, "created"
+
+    need_update = False
+
+    # 角色
+    if user.role != role:
+        user.role = role
+        need_update = True
+
+    # 密码（若不匹配，则重置为指定默认密码）
+    if not verify_password("123456" if username in {"admin", "user"} else plain_password, user.password_hash):
+        user.password_hash = hash_password(plain_password)
+        need_update = True
+
+    # 状态与风控字段重置
+    if not user.is_active:
+        user.is_active = True
+        need_update = True
+    if user.failed_login_attempts != 0 or user.lock_until is not None:
+        user.failed_login_attempts = 0
+        user.lock_until = None
+        need_update = True
+
+    return user, ("updated" if need_update else "skipped")
+
+
+def main() -> None:
+    # 初始化日志
+    init_logging(os.getenv("LOG_LEVEL"))
+    logger = get_logger()
+
+    logger.warning("运行开发/测试种子脚本，仅用于 dev/test 环境。目标数据库：%s", str(engine.url))
+
+    ensure_tables()
+
+    session: Session = SessionLocal()
+    # TODO: 支持从环境变量中读取用户名和密码，放到boot.sh中执行
+    try:
+        targets = [
+            ("admin", "123456", "admin"),
+            ("user", "123456", "user"),
+        ]
+
+        results: list[tuple[str, str, str]] = []
+        for username, password, role in targets:
+            user, action = upsert_user(session, username, password, role)
+            results.append((username, action, user.role))
+
+        session.commit()
+
+        for username, action, role in results:
+            logger.info("user=%s action=%s role=%s", username, action, role)
+
+    except Exception:  # pragma: no cover - 脚本运行时错误记录
+        session.rollback()
+        logger.exception("seed users failed")
+        raise
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/api/utils/seed_users.py
+++ b/api/utils/seed_users.py
@@ -14,12 +14,28 @@ from utils.security import hash_password, verify_password
 
 
 def ensure_tables() -> None:
-    """确保需要的表已创建(dev/test 便捷使用)."""
+    """
+    Create all ORM-mapped database tables defined on `Base`.
+    
+    Ensures the database schema for the application's models exists by invoking create_all on the module-configured engine; intended for convenient use in development and testing.
+    """
     Base.metadata.create_all(bind=engine)
 
 
 def upsert_user(session: Session, username: str, plain_password: str, role: str) -> tuple[User, str]:
-    """插入或更新用户，返回 (user, action). action ∈ {created, updated, skipped}."""
+    """
+    Insert a new user or update an existing user's credentials, role, and security state.
+    
+    If a user with the given username does not exist, a new User is created with the provided password (hashed), role, and default security fields. If the user exists, the function updates the role if different, replaces the stored password when the provided password does not match the existing hash, reactivates the account if inactive, and resets failed login and lock fields if present. The function does not commit the session; the caller is responsible for committing.
+    
+    Parameters:
+        username (str): The username to create or update.
+        plain_password (str): The plaintext password to verify against or store (will be hashed).
+        role (str): The role to assign to the user.
+    
+    Returns:
+        tuple[User, str]: A tuple containing the User instance and an action string: `'created'` if a new user was added, `'updated'` if an existing user was modified, or `'skipped'` if no changes were necessary.
+    """
     user = session.query(User).filter_by(username=username).one_or_none()
     if user is None:
         user = User(
@@ -60,6 +76,11 @@ def upsert_user(session: Session, username: str, plain_password: str, role: str)
 
 def main() -> None:
     # 初始化日志
+    """
+    Seed the development/test database with default user accounts and ensure required tables exist.
+    
+    Initializes logging from the LOG_LEVEL environment variable, creates any missing ORM tables, opens a database session, and inserts or updates a set of default user accounts (currently "admin" and "user" with the default password "123456" and respective roles). Commits the transaction when all seeds succeed; on error, rolls back the session, logs the exception, re-raises it, and always closes the session.
+    """
     init_logging(os.getenv("LOG_LEVEL"))
     logger = get_logger()
 


### PR DESCRIPTION
## Summary
This PR adds a user seeding utility for development and testing environments with the following features:

- **New `upsert_user` function**: Creates or updates admin and user accounts with proper role management
- **Idempotent seeding**: Safe to run multiple times without creating duplicates
- **Comprehensive tests**: Full test coverage for all seed functionality including edge cases
- **Argon2 integration**: Uses the existing Argon2 password hashing for security
- **Environment-specific**: Designed for dev/test environments with proper logging

## Test plan
- [x] Unit tests pass for all seed user functionality
- [x] Pre-commit hooks pass (ruff, formatting, etc.)
- [x] Tested idempotent behavior (multiple runs don't create duplicates)
- [x] Verified role updates work correctly
- [x] Confirmed password verification works with Argon2
- [x] Tested lock/failure reset functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 新增用户初始化相关单元测试，覆盖创建、幂等性、锁定/失败计数重置及角色更新等场景。
  * 更新安全测试注释以反映当前密码哈希实现，断言逻辑保持不变。

* **Chores**
  * 添加数据库种子脚本与初始化工具，可创建表并预置默认管理员与普通用户，记录操作结果并处理错误回滚。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->