### PR TITLE
feat(api): add JWT authentication with access and refresh tokens

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -23,3 +23,16 @@ DB_HOST=localhost
 DB_PORT=5432
 # 数据库名
 DB_DATABASE=fastapi-nextjs
+
+
+# =============================
+# 鉴权（JWT）
+# =============================
+# 签名密钥（请在生产环境中覆盖为安全随机值）
+JWT_SECRET=dev-secret-change-me
+# 签名算法（固定 HS256）
+JWT_ALGORITHM=HS256
+# 访问令牌有效期（分钟）
+ACCESS_TOKEN_EXPIRES_MINUTES=60
+# 刷新令牌有效期（天）
+REFRESH_TOKEN_EXPIRES_DAYS=7

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -13,3 +13,4 @@ psycopg[binary]==3.2.9
 alembic==1.16.4
 python-dotenv==1.1.1
 argon2-cffi==25.1.0
+PyJWT==2.10.1

--- a/api/tests/unit_tests/test_jwt_tokens.py
+++ b/api/tests/unit_tests/test_jwt_tokens.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import jwt
+import pytest
+
+from utils.config import settings
+from utils.jwt_tokens import (
+    TokenExpiredError,
+    TokenInvalidError,
+    TokenMissingClaimError,
+    TokenSignatureError,
+    TokenTypeError,
+    create_access_token,
+    create_refresh_token,
+    verify_token,
+)
+
+
+def _now_ts() -> int:
+    return int(datetime.now(UTC).timestamp())
+
+
+def test_create_and_verify_access_refresh_tokens() -> None:
+    user_id = uuid.uuid4()
+
+    access = create_access_token(user_id)
+    refresh = create_refresh_token(user_id)
+
+    access_claims = verify_token(access, "access")
+    refresh_claims = verify_token(refresh, "refresh")
+
+    # 基本字段
+    for claims, expected_type in [(access_claims, "access"), (refresh_claims, "refresh")]:
+        assert claims["type"] == expected_type
+        # sub/jti 为合法 UUID
+        uuid.UUID(str(claims["sub"]))
+        uuid.UUID(str(claims["jti"]))
+        assert isinstance(claims["iat"], int)
+        assert isinstance(claims["exp"], int)
+
+    # 有效期校验：exp - iat 与配置一致
+    assert access_claims["exp"] - access_claims["iat"] == settings.ACCESS_TOKEN_EXPIRES_MINUTES * 60
+    assert refresh_claims["exp"] - refresh_claims["iat"] == settings.REFRESH_TOKEN_EXPIRES_DAYS * 24 * 3600
+
+
+def test_verify_token_type_mismatch_raises() -> None:
+    token = create_access_token(uuid.uuid4())
+    with pytest.raises(TokenTypeError):
+        verify_token(token, "refresh")
+
+
+def test_verify_token_expired_raises() -> None:
+    # 构造一个已过期的 access token（exp 在过去）
+    now = _now_ts()
+    payload = {
+        "sub": str(uuid.uuid4()),
+        "type": "access",
+        "jti": str(uuid.uuid4()),
+        "iat": now - 10,
+        "exp": now - 1,
+    }
+    expired_token = jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+
+    with pytest.raises(TokenExpiredError):
+        verify_token(expired_token, "access")
+
+
+def test_verify_token_signature_error_raises() -> None:
+    # 使用错误密钥签名
+    now = _now_ts()
+    payload = {
+        "sub": str(uuid.uuid4()),
+        "type": "access",
+        "jti": str(uuid.uuid4()),
+        "iat": now,
+        "exp": now + 60,
+    }
+    wrong_secret_token = jwt.encode(payload, "other-secret", algorithm=settings.JWT_ALGORITHM)
+
+    with pytest.raises(TokenSignatureError):
+        verify_token(wrong_secret_token, "access")
+
+
+def test_verify_token_missing_required_claim_raises_invalid() -> None:
+    # 缺少 jti，decode 阶段因 require 检查触发 InvalidTokenError → TokenInvalidError
+    now = _now_ts()
+    payload = {
+        "sub": str(uuid.uuid4()),
+        "type": "access",
+        # "jti" 缺失
+        "iat": now,
+        "exp": now + 60,
+    }
+    token = jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+
+    with pytest.raises(TokenInvalidError):
+        verify_token(token, "access")
+
+
+def test_verify_token_malformed_uuid_claims_raises_missing_claim_error() -> None:
+    # jti 与 sub 存在但不是合法 UUID
+    now = _now_ts()
+    payload = {
+        "sub": "not-a-uuid",
+        "type": "access",
+        "jti": "also-not-a-uuid",
+        "iat": now,
+        "exp": now + 60,
+    }
+    token = jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+
+    with pytest.raises(TokenMissingClaimError):
+        verify_token(token, "access")
+
+
+def test_verify_token_malformed_timestamps_raises_missing_claim_error() -> None:
+    # iat/exp 必须为整数
+    payload = {
+        "sub": str(uuid.uuid4()),
+        "type": "access",
+        "jti": str(uuid.uuid4()),
+        "iat": "not-int",
+        "exp": "not-int",
+    }
+    token = jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+
+    with pytest.raises(TokenMissingClaimError):
+        verify_token(token, "access")

--- a/api/utils/config.py
+++ b/api/utils/config.py
@@ -46,6 +46,12 @@ class Settings:
     - DB_HOST: 数据库主机。默认 localhost
     - DB_PORT: 数据库端口。默认 5432
     - DB_DATABASE: 数据库名。默认 fastapi-nextjs
+
+    鉴权（JWT）
+    - JWT_SECRET: 签名密钥（HS256）。默认 dev-secret-change-me（请在生产环境中覆盖）
+    - JWT_ALGORITHM: 签名算法。固定 HS256
+    - ACCESS_TOKEN_EXPIRES_MINUTES: 访问令牌有效期（分钟）。默认 60
+    - REFRESH_TOKEN_EXPIRES_DAYS: 刷新令牌有效期（天）。默认 7
     """
 
     def __init__(self) -> None:
@@ -59,6 +65,13 @@ class Settings:
         self.DB_HOST: str = os.getenv("DB_HOST", "localhost")
         self.DB_PORT: str = os.getenv("DB_PORT", "5432")
         self.DB_DATABASE: str = os.getenv("DB_DATABASE", "fastapi-nextjs")
+
+        # JWT 配置
+        self.JWT_SECRET: str = os.getenv("JWT_SECRET", "dev-secret-change-me")
+        self.JWT_ALGORITHM: str = os.getenv("JWT_ALGORITHM", "HS256")
+        # 允许字符串或数字，统一转为 int
+        self.ACCESS_TOKEN_EXPIRES_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRES_MINUTES", "60"))
+        self.REFRESH_TOKEN_EXPIRES_DAYS: int = int(os.getenv("REFRESH_TOKEN_EXPIRES_DAYS", "7"))
 
         # 构造函数不打印日志，避免多次实例化导致重复日志
 
@@ -87,6 +100,10 @@ class Settings:
             "DB_HOST": self.DB_HOST,
             "DB_PORT": self.DB_PORT,
             "DB_DATABASE": self.DB_DATABASE,
+            "JWT_SECRET": "***" if self.JWT_SECRET else "",
+            "JWT_ALGORITHM": self.JWT_ALGORITHM,
+            "ACCESS_TOKEN_EXPIRES_MINUTES": self.ACCESS_TOKEN_EXPIRES_MINUTES,
+            "REFRESH_TOKEN_EXPIRES_DAYS": self.REFRESH_TOKEN_EXPIRES_DAYS,
         }
 
 

--- a/api/utils/jwt_tokens.py
+++ b/api/utils/jwt_tokens.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+import jwt
+
+from utils.config import settings
+
+
+class TokenError(Exception):
+    """通用 Token 异常基类"""
+
+
+class TokenExpiredError(TokenError):
+    """令牌已过期"""
+
+
+class TokenSignatureError(TokenError):
+    """令牌签名无效"""
+
+
+class TokenTypeError(TokenError):
+    """令牌类型与预期不符"""
+
+
+class TokenMissingClaimError(TokenError):
+    """必需声明缺失或格式不正确"""
+
+
+class TokenInvalidError(TokenError):
+    """令牌非法或无法解析"""
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _uuid_str() -> str:
+    return str(uuid.uuid4())
+
+
+def _normalize_user_id(user_id: Any) -> str:
+    """将入参 user_id 统一为 UUID 字符串，若失败抛出 TokenMissingClaimError。"""
+    try:
+        # 允许传入 UUID 对象或字符串
+        if isinstance(user_id, uuid.UUID):
+            return str(user_id)
+        return str(uuid.UUID(str(user_id)))
+    except Exception as e:
+        raise TokenMissingClaimError("`sub`(用户ID) 不是合法 UUID") from e
+
+
+def _build_common_claims(
+    user_id: Any, token_type: Literal["access", "refresh"], expires_delta: timedelta
+) -> dict[str, Any]:
+    issued_at = _now()
+    claims: dict[str, Any] = {
+        "sub": _normalize_user_id(user_id),
+        "type": token_type,
+        "jti": _uuid_str(),
+        "iat": int(issued_at.timestamp()),
+        "exp": int((issued_at + expires_delta).timestamp()),
+    }
+    return claims
+
+
+def create_access_token(user_id: Any) -> str:
+    """签发访问令牌（有效期：settings.ACCESS_TOKEN_EXPIRES_MINUTES）。"""
+    expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRES_MINUTES)
+    payload = _build_common_claims(user_id, "access", expires)
+    token = jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM, headers={"typ": "JWT"})
+    return token
+
+
+def create_refresh_token(user_id: Any) -> str:
+    """签发刷新令牌（有效期：settings.REFRESH_TOKEN_EXPIRES_DAYS）。"""
+    expires = timedelta(days=settings.REFRESH_TOKEN_EXPIRES_DAYS)
+    payload = _build_common_claims(user_id, "refresh", expires)
+    token = jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM, headers={"typ": "JWT"})
+    return token
+
+
+def verify_token(token: str, expected_type: Literal["access", "refresh"]) -> dict[str, Any]:
+    """
+    验证并解析令牌。
+
+    - 校验签名、过期时间（exp）。
+    - 校验 `type` 与 expected_type 一致。
+    - 校验 `sub`/`jti`/`iat`/`exp` 存在且格式正确。
+
+    Returns: 已验证的 claims 字典
+    Raises: TokenExpiredError, TokenSignatureError, TokenTypeError, TokenMissingClaimError, TokenInvalidError
+    """
+    try:
+        # 关闭对 iat/exp 的内建校验，改为在下方进行自定义校验
+        claims = jwt.decode(
+            token,
+            settings.JWT_SECRET,
+            algorithms=[settings.JWT_ALGORITHM],
+            options={
+                "require": ["exp", "iat", "sub", "jti", "type"],
+                "verify_exp": False,
+                "verify_iat": False,
+            },
+        )
+    except jwt.ExpiredSignatureError as e:
+        # 一般不会触发（已关闭 verify_exp），保底处理
+        raise TokenExpiredError("令牌已过期") from e
+    except jwt.InvalidSignatureError as e:
+        raise TokenSignatureError("令牌签名无效") from e
+    except jwt.InvalidTokenError as e:
+        # 其他解码错误归并为非法令牌
+        raise TokenInvalidError("非法令牌或解析失败") from e
+
+    # 类型校验
+    token_type = claims.get("type")
+    if token_type != expected_type:
+        raise TokenTypeError(f"令牌类型错误：期望 {expected_type}，实际 {token_type}")
+
+    # 必需字段与格式进一步校验
+    # sub / jti 必须是 UUID 字符串
+    for key in ("sub", "jti"):
+        value = claims.get(key)
+        if not value:
+            raise TokenMissingClaimError(f"缺少必需声明: {key}")
+        try:
+            uuid.UUID(str(value))
+        except Exception as e:
+            raise TokenMissingClaimError(f"声明 {key} 不是合法 UUID") from e
+
+    # iat/exp 必须是整数时间戳
+    for key in ("iat", "exp"):
+        value = claims.get(key)
+        if value is None:
+            raise TokenMissingClaimError(f"缺少必需声明: {key}")
+        if not isinstance(value, int):
+            raise TokenMissingClaimError(f"声明 {key} 需要为整数时间戳")
+
+    # 过期校验（因关闭 verify_exp，需要在此处手动判断）
+    now_ts = int(_now().timestamp())
+    if now_ts >= int(claims["exp"]):
+        raise TokenExpiredError("令牌已过期")
+
+    return claims


### PR DESCRIPTION
## Summary
This PR implements JWT authentication functionality for the API with access and refresh tokens.

## Changes
- Added JWT configuration to `.env.example` and `config.py`
- Implemented JWT token utilities (`jwt_tokens.py`) with:
  - Access token creation and verification
  - Refresh token creation and verification  
  - Comprehensive error handling with custom exceptions
  - UUID validation for user IDs
  - Configurable token expiration times
- Added comprehensive unit tests for JWT functionality
- Updated requirements.txt with PyJWT dependency

## Test plan
- [x] Unit tests pass for JWT token creation and verification
- [x] Error handling tests for expired tokens, invalid signatures, type mismatches
- [x] Configuration validation tests
- [x] Pre-commit hooks pass (ruff formatting and linting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 实现了JWT令牌认证系统，支持访问令牌和刷新令牌的创建与验证
  * 添加了灵活的令牌过期时间配置

* **测试**
  * 新增JWT令牌处理的全面单元测试，覆盖令牌创建、验证及各类异常场景

<!-- end of auto-generated comment: release notes by coderabbit.ai -->