### PR TITLE
feat(api): implement JWT refresh token rotation with family-based revocation

### DIFF
--- a/api/models/refresh_tokens.py
+++ b/api/models/refresh_tokens.py
@@ -44,9 +44,15 @@ class RefreshToken(Base):
         Index("refresh_tokens_expires_at_idx", "expires_at"),
     )
 
+    def _as_utc(self, dt: datetime) -> datetime:
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC)
+
     def is_expired(self, now: datetime | None = None) -> bool:
-        ref = now or datetime.now(UTC)
-        return ref >= self.expires_at
+        ref = self._as_utc(now) if isinstance(now, datetime) else datetime.now(UTC)
+        exp = self._as_utc(self.expires_at)
+        return ref >= exp
 
     def mark_used(self, when: datetime | None = None) -> None:
         self.used_at = when or datetime.now(UTC)

--- a/api/tests/integration_tests/test_auth_refresh_integration.py
+++ b/api/tests/integration_tests/test_auth_refresh_integration.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import jwt
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from models import RefreshToken, User
+from utils.config import settings
+from utils.security import hash_password
+
+
+def _create_user(db: Session, username: str, password: str, *, is_active: bool = True) -> User:
+    user = User(username=username, password_hash=hash_password(password), role="user", is_active=is_active)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+# 正常刷新：仅依赖 Cookie 中的 refresh_token，返回新 access 并轮换出新的 refresh；
+# 旧刷新记录 used_at 应置位，新刷新写入 Cookie（值变化）。
+def test_refresh_endpoint_success_sets_new_cookie(client: TestClient, db_session: Session) -> None:
+    _create_user(db_session, "eve", "pw")
+
+    r1 = client.post("/api/auth/login", json={"username": "eve", "password": "pw"})
+    assert r1.status_code == 200
+    old_cookie = r1.cookies.get("refresh_token")
+    assert old_cookie
+
+    r2 = client.post("/api/auth/refresh")
+    assert r2.status_code == 200
+    body = r2.json()
+    assert body["code"] == 0
+    assert "access_token" in (body.get("data") or {})
+
+    new_cookie = r2.cookies.get("refresh_token")
+    assert new_cookie
+    assert isinstance(new_cookie, str)
+    assert new_cookie != old_cookie
+
+    # DB 状态：旧记录 used_at 置位 + 新记录插入
+    tokens = db_session.query(RefreshToken).all()
+    assert len(tokens) == 2
+    old = next(t for t in tokens if t.parent_jti is None)
+    child = next(t for t in tokens if t.parent_jti == old.jti)
+    assert old.used_at is not None
+    assert child is not None
+
+
+# 复用检测：同一旧 refresh 再次使用，服务应撤销该家族全部刷新令牌，
+# 接口返回 40112；随后即便携带较新的 refresh 也应失败。
+def test_refresh_endpoint_reuse_revokes_family(client: TestClient, db_session: Session) -> None:
+    _create_user(db_session, "frank", "pw")
+
+    r1 = client.post("/api/auth/login", json={"username": "frank", "password": "pw"})
+    assert r1.status_code == 200
+    cookie_initial = r1.cookies.get("refresh_token")
+    assert cookie_initial
+
+    # 第一次刷新（正常）
+    r2 = client.post("/api/auth/refresh")
+    assert r2.json()["code"] == 0
+    cookie_after = r2.cookies.get("refresh_token")
+    assert cookie_after
+
+    # 复用最初的旧 cookie 进行第二次刷新
+    client.cookies.set("refresh_token", cookie_initial)
+    r3 = client.post("/api/auth/refresh")
+    assert r3.status_code == 200
+    assert r3.json()["code"] == 40112
+
+    # 家族全部撤销：随后即便使用较新的 cookie 也应失败
+    client.cookies.set("refresh_token", cookie_after)
+    r4 = client.post("/api/auth/refresh")
+    assert r4.status_code == 200
+    assert r4.json()["code"] != 0
+
+    db_session.expire_all()
+    tokens = db_session.query(RefreshToken).all()
+    assert len(tokens) >= 2
+    assert all(t.revoked for t in tokens)
+
+
+# 过期刷新：携带已过期的 refresh_token 时，接口返回 40111，刷新失败。
+def test_refresh_endpoint_with_expired_token_returns_401(client: TestClient, db_session: Session) -> None:
+    user = _create_user(db_session, "gina", "pw")
+
+    # 构造过期的 refresh JWT，并写入匹配的 DB 记录
+    now = int(datetime.now(UTC).timestamp())
+    payload = {
+        "sub": str(user.id),
+        "type": "refresh",
+        "jti": str(uuid4()),
+        "iat": now - 100,
+        "exp": now - 1,
+    }
+    expired_token = jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+    rt = RefreshToken(
+        jti=payload["jti"],
+        parent_jti=None,
+        user_id=user.id,
+        issued_at=datetime.fromtimestamp(payload["iat"], UTC),
+        expires_at=datetime.fromtimestamp(payload["exp"], UTC),
+        revoked=False,
+        revoked_reason=None,
+        device_id=None,
+        ip=None,
+        user_agent=None,
+    )
+    db_session.add(rt)
+    db_session.commit()
+
+    client.cookies.set("refresh_token", expired_token)
+    r = client.post("/api/auth/refresh")
+    assert r.status_code == 200
+    assert r.json()["code"] == 40111

--- a/api/tests/unit_tests/test_auth_refresh.py
+++ b/api/tests/unit_tests/test_auth_refresh.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import jwt
+
+from models import RefreshToken, User
+from services.auth_service import AuthService
+from utils.config import settings
+from utils.jwt_tokens import create_refresh_token, verify_token
+from utils.security import hash_password
+
+
+def _create_user(db, username: str, password: str) -> User:
+    user = User(username=username, password_hash=hash_password(password), role="user", is_active=True)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _persist_refresh(db, user: User) -> tuple[str, RefreshToken]:
+    token = create_refresh_token(user.id)
+    claims = verify_token(token, "refresh")
+    issued_at = datetime.fromtimestamp(int(claims["iat"]), UTC)
+    expires_at = datetime.fromtimestamp(int(claims["exp"]), UTC)
+    rt = RefreshToken(
+        jti=str(claims["jti"]),
+        parent_jti=None,
+        user_id=user.id,
+        issued_at=issued_at,
+        expires_at=expires_at,
+        revoked=False,
+        revoked_reason=None,
+        device_id=None,
+        ip=None,
+        user_agent=None,
+    )
+    db.add(rt)
+    db.commit()
+    return token, rt
+
+
+# 服务层：刷新成功的轮换流程——旧刷新令牌 used_at 置位；
+# 新刷新令牌插入且 parent_jti 指向旧 jti，同时返回新的 access_token。
+def test_refresh_rotate_success(db_session) -> None:
+    user = _create_user(db_session, "r1", "pw")
+    token, rt = _persist_refresh(db_session, user)
+
+    service = AuthService()
+    result = service.refresh(db=db_session, refresh_token=token)
+
+    assert result["code"] == 0
+    assert "access_token" in (result.get("data") or {})
+
+    db_session.expire_all()
+    old = db_session.query(RefreshToken).filter(RefreshToken.jti == rt.jti).first()
+    assert old is not None
+    assert old.used_at is not None
+
+    # 新纪录插入且 parent_jti 指向旧 jti
+    children = db_session.query(RefreshToken).filter(RefreshToken.parent_jti == rt.jti).all()
+    assert len(children) == 1
+
+
+# 服务层：复用检测——同一刷新令牌第二次使用将被识别为复用；
+# 服务撤销整个家族的刷新令牌（全部 revoked=true）。
+def test_refresh_reuse_detects_and_revokes_family(db_session) -> None:
+    user = _create_user(db_session, "r2", "pw")
+    token, rt = _persist_refresh(db_session, user)
+
+    service = AuthService()
+    first = service.refresh(db=db_session, refresh_token=token)
+    assert first["code"] == 0
+
+    # 复用旧 token
+    second = service.refresh(db=db_session, refresh_token=token)
+    assert second["code"] == 40112
+
+    # 家族内所有刷新令牌应被撤销
+    db_session.expire_all()
+    tokens = db_session.query(RefreshToken).all()
+    assert len(tokens) >= 2
+    assert all(t.revoked for t in tokens)
+
+    # 使用子令牌也应失败
+    child = next(t for t in tokens if t.parent_jti == rt.jti)
+    # 为了避免复杂化 JWT 重签名，这里直接断言 DB 层已撤销即可
+    assert child.revoked is True
+
+
+# 服务层：过期刷新——传入已过期的 refresh_token 时，返回 40111（刷新令牌已过期）。
+def test_refresh_expired_returns_401(db_session) -> None:
+    user = _create_user(db_session, "r3", "pw")
+
+    now = int(datetime.now(UTC).timestamp())
+    payload = {
+        "sub": str(user.id),
+        "type": "refresh",
+        "jti": str(uuid4()),
+        "iat": now - 100,
+        "exp": now - 1,
+    }
+    expired_token = jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+
+    rt = RefreshToken(
+        jti=payload["jti"],
+        parent_jti=None,
+        user_id=user.id,
+        issued_at=datetime.fromtimestamp(payload["iat"], UTC),
+        expires_at=datetime.fromtimestamp(payload["exp"], UTC),
+        revoked=False,
+        revoked_reason=None,
+        device_id=None,
+        ip=None,
+        user_agent=None,
+    )
+    db_session.add(rt)
+    db_session.commit()
+
+    service = AuthService()
+    result = service.refresh(db=db_session, refresh_token=expired_token)
+    assert result["code"] == 40111


### PR DESCRIPTION
## Summary
This PR implements secure JWT refresh token functionality with token rotation and family-based revocation to prevent token reuse attacks.

## Key Features
- **Token Rotation**: Each refresh generates new access and refresh tokens
- **Family-based Revocation**: All tokens in a family are revoked if reuse is detected
- **Reuse Detection**: Prevents replay attacks by detecting when old tokens are reused
- **Comprehensive Testing**: Both unit and integration tests for all scenarios

## Implementation Details
- Added /auth/refresh endpoint in api/controllers/auth_controller.py:54-87
- Enhanced RefreshToken model with timezone-aware expiration checking in api/models/refresh_tokens.py:47-52
- Implemented complete refresh service with family token management in api/services/auth_service.py:159-292
- Added comprehensive test coverage for success, reuse detection, and expiration scenarios

## Security Features
- Token family tracking via parent_jti relationships
- Automatic revocation of entire token family on reuse detection
- Proper timezone handling for expiration checks
- Secure cookie-based refresh token storage

## Test Coverage
- Unit tests for service layer functionality
- Integration tests for complete refresh flow
- Tests for token reuse detection and family revocation
- Tests for expired token handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增令牌刷新端点，支持会话持续化而无需重新登录
  * 实现令牌轮换机制，增强会话安全性
  * 添加令牌重用检测，自动撤销受影响的会话

* **测试**
  * 新增集成测试覆盖令牌刷新流程、重用检测和过期处理
  * 新增单元测试验证令牌轮换和安全撤销逻辑

<!-- end of auto-generated comment: release notes by coderabbit.ai -->