### PR TITLE
ci(docker): remove push trigger from only-build workflow

### DIFF
--- a/.github/workflows/only-build.yaml
+++ b/.github/workflows/only-build.yaml
@@ -1,9 +1,6 @@
 name: Only Build
 
 on:
-  push:
-    branches-ignore:
-      - "main"
   pull_request:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
Removed the push trigger from the only-build workflow to optimize CI/CD pipeline performance.

## Changes
- Removed `push` trigger with `branches-ignore: ["main"]` from the workflow
- Workflow now only runs on:
  - Pull requests to main branch
  - Manual workflow dispatch

## Benefits
- Reduces unnecessary workflow runs on feature branches
- Focuses CI resources on PR validation and manual triggers
- Maintains build validation for all PRs before merge

## Test plan
- [x] Verify workflow still triggers on PR creation
- [x] Verify manual dispatch still works
- [x] Confirm no impact on main branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化构建工作流触发器配置，现仅在pull request创建和手动触发时执行，提高构建效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->