### PR TITLE
refactor(api): migrate students module to async database access with psycopg_async

### DIFF
--- a/api/controllers/students_controller.py
+++ b/api/controllers/students_controller.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, Query
-from fastapi.concurrency import run_in_threadpool
 
 from core.rbac import Admin, UserOrAdmin
 from schemas.students import StudentCreateRequest, StudentsListResponse
 from services.students_service import StudentsService
-from utils.db import DbSession
+from utils.db import AsyncDbSession
 
 router = APIRouter()
 
@@ -18,25 +17,23 @@ async def list_students(
     page: int = Query(1, ge=1),
     page_size: int = Query(100, ge=1, le=100),
     _viewer: UserOrAdmin = None,
-    db: DbSession = None,
+    db: AsyncDbSession = None,
 ) -> dict[str, Any]:
     service = StudentsService()
-    return await run_in_threadpool(lambda: service.list_students(db=db, page=page, page_size=page_size))
+    return await service.list_students(db=db, page=page, page_size=page_size)
 
 
 @router.post("/students")
 async def create_student(
     payload: StudentCreateRequest,
     _admin: Admin = None,
-    db: DbSession = None,
+    db: AsyncDbSession = None,
 ) -> dict[str, Any]:
     service = StudentsService()
-    return await run_in_threadpool(
-        lambda: service.create_student(
-            db=db,
-            name=payload.name,
-            gender=payload.gender,
-            student_id=payload.student_id,
-            age=payload.age,
-        )
+    return await service.create_student(
+        db=db,
+        name=payload.name,
+        gender=payload.gender,
+        student_id=payload.student_id,
+        age=payload.age,
     )

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,6 +4,7 @@ pydantic[email]==2.11.7
 uvicorn[standard]==0.35.0
 httpx==0.28.1
 pytest==8.4.1
+pytest-asyncio==1.2.0
 pytest-mock==3.14.1
 pytest-cov==6.2.1
 ruff==0.12.8
@@ -18,3 +19,4 @@ argon2-cffi==25.1.0
 # 建议：运行一次依赖安全扫描；若暂不能立即升级，请采取权宜控制
 # （如：强制最小密钥长度、禁用不安全算法、严格校验 alg/iss/aud 等）
 PyJWT==2.10.1
+aiosqlite==0.21.0

--- a/api/services/students_service.py
+++ b/api/services/students_service.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy.orm import Session
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.students import Student
 from utils.logging import get_logger
@@ -11,14 +12,17 @@ logger = get_logger()
 
 
 class StudentsService:
-    def list_students(self, *, db: Session, page: int = 1, page_size: int = 100) -> dict[str, Any]:
+    async def list_students(self, *, db: AsyncSession, page: int = 1, page_size: int = 100) -> dict[str, Any]:
         try:
             page = max(1, page)
             page_size = max(1, min(page_size, 100))
 
-            base_query = db.query(Student)
-            total: int = base_query.count()
-            items = base_query.order_by(Student.id.desc()).offset((page - 1) * page_size).limit(page_size).all()
+            stmt_items = select(Student).order_by(Student.id.desc()).offset((page - 1) * page_size).limit(page_size)
+            result_items = await db.execute(stmt_items)
+            items = result_items.scalars().all()
+
+            total_stmt = select(func.count(Student.id))
+            total: int = int(await db.scalar(total_stmt) or 0)
 
             return {
                 "code": 0,
@@ -34,17 +38,17 @@ class StudentsService:
             logger.exception("List students failed")
             return {"code": 50001, "message": "查询学生列表失败"}
 
-    def create_student(
-        self, *, db: Session, name: str, gender: str, student_id: str, age: int | None = None
+    async def create_student(
+        self, *, db: AsyncSession, name: str, gender: str, student_id: str, age: int | None = None
     ) -> dict[str, Any]:
         try:
             # 唯一键 student_id 冲突交由数据库约束抛错
             student = Student(name=name, gender=gender, age=age, student_id=student_id)
             db.add(student)
-            db.commit()
-            db.refresh(student)
+            await db.commit()
+            await db.refresh(student)
             return {"code": 0, "message": "ok", "data": student.to_dict()}
         except Exception:
-            db.rollback()
+            await db.rollback()
             logger.exception("Create student failed")
             return {"code": 50002, "message": "新增学生失败"}

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -3,9 +3,12 @@ import sys
 from collections.abc import Generator
 
 import pytest
+import pytest_asyncio
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -28,7 +31,7 @@ _ensure_api_dir_on_syspath()
 # 现在可以安全导入 api 包内模块
 from app import app as fastapi_app  # noqa: E402
 from models.base import Base  # noqa: E402
-from utils.db import get_db  # noqa: E402
+from utils.db import get_async_db, get_db  # noqa: E402
 
 
 @pytest.fixture(scope="session")
@@ -65,6 +68,29 @@ def db_session(test_engine) -> Generator[Session, None, None]:
         session.close()
 
 
+@pytest_asyncio.fixture
+async def async_test_engine():
+    # 使用内存 aiosqlite；函数级作用域，确保测试隔离
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        future=True,
+        echo=False,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def async_db_session(async_test_engine) -> AsyncSession:
+    async_session_local = async_sessionmaker(bind=async_test_engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session_local() as session:
+        yield session
+
+
 @pytest.fixture
 def client(app: FastAPI, test_engine) -> Generator[TestClient, None, None]:
     testing_session_local = sessionmaker(
@@ -84,3 +110,35 @@ def client(app: FastAPI, test_engine) -> Generator[TestClient, None, None]:
             yield c
     finally:
         app.dependency_overrides.pop(get_db, None)
+
+
+# 提供异步 HTTP 客户端，驱动 ASGI 应用进行端到端异步调用
+@pytest_asyncio.fixture
+async def async_client(app: FastAPI, test_engine, async_test_engine) -> AsyncClient:
+    # 同步会话（用于仍依赖同步 DB 的依赖路径）
+    testing_session_local = sessionmaker(
+        bind=test_engine, autoflush=False, autocommit=False, future=True, expire_on_commit=False
+    )
+    # 异步会话（用于 students 等已异步化模块）
+    async_session_local = async_sessionmaker(bind=async_test_engine, class_=AsyncSession, expire_on_commit=False)
+
+    def _override_get_db() -> Generator[Session, None, None]:
+        session: Session = testing_session_local()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    async def _override_get_async_db():
+        async with async_session_local() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_async_db] = _override_get_async_db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(get_async_db, None)

--- a/api/tests/integration_tests/test_students_api.py
+++ b/api/tests/integration_tests/test_students_api.py
@@ -1,3 +1,4 @@
+import pytest
 from sqlalchemy.orm import Session
 
 from core.jwt_tokens import create_access_token
@@ -6,14 +7,15 @@ from tests.helpers import create_user
 API_PREFIX = "/api"
 
 
-def test_create_and_list_students(client, db_session: Session):
+@pytest.mark.asyncio
+async def test_create_and_list_students(async_client, db_session: Session):
     # 创建管理员并生成访问令牌
     admin = create_user(db_session, "admin_students", "123456", role="admin")
     access = create_access_token(admin.id, admin.role)
     headers = {"Authorization": f"Bearer {access}"}
 
     payload = {"name": "Alice", "gender": "female", "student_id": "S1001", "age": 18}
-    resp = client.post(f"{API_PREFIX}/students", json=payload, headers=headers)
+    resp = await async_client.post(f"{API_PREFIX}/students", json=payload, headers=headers)
     assert resp.status_code == 200
     body = resp.json()
     assert body["code"] == 0
@@ -21,35 +23,37 @@ def test_create_and_list_students(client, db_session: Session):
     assert data["id"] > 0
     assert data["student_id"] == payload["student_id"]
 
-    list_resp = client.get(f"{API_PREFIX}/students?page=1&page_size=10", headers=headers)
+    list_resp = await async_client.get(f"{API_PREFIX}/students?page=1&page_size=10", headers=headers)
     assert list_resp.status_code == 200
     items = list_resp.json()["data"]["items"]
     assert any(it["student_id"] == payload["student_id"] for it in items)
 
 
-def test_user_cannot_create_students_forbidden(client, db_session: Session):
+@pytest.mark.asyncio
+async def test_user_cannot_create_students_forbidden(async_client, db_session: Session):
     # 普通用户
     user = create_user(db_session, "user_students", "123456", role="user")
     access = create_access_token(user.id, user.role)
     headers = {"Authorization": f"Bearer {access}"}
 
     payload = {"name": "Bob", "gender": "male", "student_id": "S2001", "age": 19}
-    resp = client.post(f"{API_PREFIX}/students", json=payload, headers=headers)
+    resp = await async_client.post(f"{API_PREFIX}/students", json=payload, headers=headers)
     assert resp.status_code == 403
 
 
-def test_user_can_list_students(client, db_session: Session):
+@pytest.mark.asyncio
+async def test_user_can_list_students(async_client, db_session: Session):
     # 先由管理员创建一条记录，确保列表非空
     admin = create_user(db_session, "admin_students_2", "123456", role="admin")
     admin_access = create_access_token(admin.id, admin.role)
     admin_headers = {"Authorization": f"Bearer {admin_access}"}
     payload = {"name": "Cindy", "gender": "female", "student_id": "S3001", "age": 20}
-    _ = client.post(f"{API_PREFIX}/students", json=payload, headers=admin_headers)
+    _ = await async_client.post(f"{API_PREFIX}/students", json=payload, headers=admin_headers)
 
     # 普通用户访问列表应 200
     user = create_user(db_session, "user_students_2", "123456", role="user")
     user_access = create_access_token(user.id, user.role)
     user_headers = {"Authorization": f"Bearer {user_access}"}
 
-    list_resp = client.get(f"{API_PREFIX}/students?page=1&page_size=10", headers=user_headers)
+    list_resp = await async_client.get(f"{API_PREFIX}/students?page=1&page_size=10", headers=user_headers)
     assert list_resp.status_code == 200

--- a/api/tests/unit_tests/test_students_service.py
+++ b/api/tests/unit_tests/test_students_service.py
@@ -1,12 +1,23 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from models.base import Base
 from services.students_service import StudentsService
 
 
-def test_list_students_empty(db_session):
-    service = StudentsService()
-    resp = service.list_students(db=db_session, page=1, page_size=10)
-    assert resp["code"] == 0
-    assert resp["message"] == "ok"
-    assert resp["data"]["items"] == []
-    assert resp["data"]["page"] == 1
-    assert resp["data"]["page_size"] == 10
-    assert resp["data"]["total"] == 0
+@pytest.mark.asyncio
+async def test_list_students_empty():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_local = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_local() as session:
+        service = StudentsService()
+        resp = await service.list_students(db=session, page=1, page_size=10)
+        assert resp["code"] == 0
+        assert resp["message"] == "ok"
+        assert resp["data"]["items"] == []
+        assert resp["data"]["page"] == 1
+        assert resp["data"]["page_size"] == 10
+        assert resp["data"]["total"] == 0
+    await engine.dispose()

--- a/api/utils/db_url.py
+++ b/api/utils/db_url.py
@@ -14,3 +14,14 @@ def build_database_url() -> URL:
         port=int(settings.DB_PORT),
         database=settings.DB_DATABASE,
     )
+
+
+def build_async_database_url() -> URL:
+    return URL.create(
+        "postgresql+psycopg_async",
+        username=settings.DB_USERNAME,
+        password=settings.DB_PASSWORD,
+        host=settings.DB_HOST,
+        port=int(settings.DB_PORT),
+        database=settings.DB_DATABASE,
+    )

--- a/spec/async-db-refactor.md
+++ b/spec/async-db-refactor.md
@@ -1,0 +1,93 @@
+# FastAPI + PostgreSQL 异步化重构（需求文档）
+
+## 需求描述
+当前后端（FastAPI）使用 SQLAlchemy 同步会话（`Session`）访问数据库，并通过 `run_in_threadpool` 在路由层包裹阻塞查询。这种方式会带来线程池切换开销、难以充分利用 asyncio 并发能力，且在高并发或 I/O 密集场景下吞吐受限。需要将数据库访问改造为原生异步（`AsyncEngine` + `AsyncSession`），消除线程池包装，落实 FastAPI + PostgreSQL 的异步最佳实践。
+
+## 需求目标
+- 将数据库访问改造为基于 SQLAlchemy 2.x 的异步访问栈（`AsyncEngine`/`AsyncSession`）。
+- 移除控制器层的 `run_in_threadpool` 包装，端到端异步。
+- 维持现有 API 契约与业务行为（返回结构、校验逻辑、错误码）不变。
+- 提升在 I/O 密集负载下的吞吐与并发能力，降低 P95 响应时间。
+- 保证观测性、可回滚、可灰度发布。
+
+## 技术方案（最佳实践）
+
+### 选型
+- ORM 与会话：SQLAlchemy >= 2.0（原生 async API）。
+- 驱动：使用 `psycopg3` 异步驱动（`postgresql+psycopg_async://`）。
+  - 理由：持续维护、与 SQLAlchemy 2.x 贴合、生态成熟。
+- 连接池：使用 SQLAlchemy 内置连接池（无 PgBouncer 前提）。
+- 迁移：Alembic（保留原流程，不强制改造）。
+
+### 架构改造概览
+1) 应用生命周期与依赖注入
+- 在现有数据库初始化位置，将同步引擎与会话改造为 `AsyncEngine` 与 `async_sessionmaker(class_=AsyncSession)`，不新增文件。
+- 现有依赖注入保持形式不变，但改造为异步 `yield` 出单请求范围的 `AsyncSession`，并采用 `async with session.begin()` 控制事务。
+
+2) 路由（Controller）层
+- 移除 `run_in_threadpool`，路由保持 `async def`，直接 `await` 调用 service。
+- 保留 RBAC/鉴权依赖不变；所有需要 DB 的依赖改用 `AsyncSession`。
+
+3) Service/Repository 层
+- 将方法签名改为异步（`async def`），接受 `AsyncSession`。
+- 查询采用 SQLAlchemy 2.x 的 `select()`/`insert()`/`update()`/`delete()` 与 `await session.execute(...)`。
+- 读操作尽量使用 `scalars()`/`scalar_one()`；写操作置于 `async with session.begin():` 事务块中；必要时手动 `await session.flush()`。
+- 分页查询采用 `select(Model).order_by(...).offset(...).limit(...)`；计数使用 `select(func.count(...))`，避免对全量 `Query.count()` 的隐式陷阱。
+
+4) 模型与模式迁移
+- ORM 模型基本不变；若当前为声明性映射（Declarative），可直接复用。
+- Alembic 继续维护迁移脚本，运行仍使用同步引擎连接（Alembic 默认支持）；亦可配置异步运行（可选）。
+
+### 连接管理与池化（PostgreSQL 最佳实践）
+- 连接 URL（示例，psycopg3 async）：
+  - `postgresql+psycopg_async://user:pass@host:5432/dbname`
+- 引擎参数：尽量与当前同步连接池参数保持一致（如 `pool_size`、`max_overflow`、`pool_recycle`、`pool_pre_ping` 等），如当前未配置则沿用 SQLAlchemy 默认值；仅在 psycopg3 需要时新增 `connect_args`（例如合理的 `statement_timeout`）。
+
+### 事务与一致性
+- 以「短事务」为原则，避免在事务中做网络 I/O。
+- 严格在 `async with session.begin()` 中进行写操作；读操作默认非事务，若有一致性要求可启用 REPEATABLE READ 并限时。
+- 并发竞争策略：
+  - 基于唯一约束 + 捕获异常（幂等写入）。
+  - 需要排他时可使用 `with_for_update(skip_locked=True)` 实现任务抢占。
+- 大批量写入采用批处理并显式 `flush`，避免事务过大。
+
+### 错误处理与超时
+- 统一捕获 SQL 异常，映射为统一错误码（维持现状语义）。
+- 在业务层设置「数据库操作级」超时（如 3~5s），并结合 PostgreSQL `statement_timeout` 双保险。
+- 对外仅暴露业务语义，隐藏底层数据库错误细节（安全）。
+
+### 可观测性与诊断
+- SQLAlchemy 日志：在本地与预发开启 `echo=False` + `pool_logging`；错误路径附带 `query_id`。
+- Tracing：OpenTelemetry（FastAPI + SQLAlchemy instrumentation），打点关键 DB 调用，产出慢查询分布。
+- 关键指标：连接池使用率、等待时间、错误率、P95/P99 RT、超时计数。
+
+### 本地开发与测试
+- 单元测试：引入 `pytest-asyncio`；使用 sqlite 进行功能验证（不引入 PostgreSQL 测试）。
+- 集成与性能测试：本阶段不进行 PostgreSQL 集成测试与压力测试，仅验证功能正确性。
+
+### 兼容与迁移策略
+- 本期范围仅改造 students 模块为异步数据库访问，直接在现有实现上重构（不新增并行的异步实现或新文件）。
+- 路由移除 `run_in_threadpool`，端到端异步；其他模块暂保持不变，后续再行推广。
+- 保持 API 契约不变；不引入双栈灰度。
+
+### 安全与合规
+- 连接串不落盘，统一从环境变量注入（K8s Secret/平台密钥）。
+- 权限最小化：只授予应用所需 schema 权限。
+- 审计：开启数据库审计日志（按合规要求）。
+
+## 影响面
+- 基础设施：数据库初始化、依赖注入、应用生命周期。
+- 控制器：路由函数签名与调用方式（移除 `run_in_threadpool`）。
+- Service/Repository：方法签名与查询方式改为异步。
+- 测试：异步测试工具链与夹具（fixtures）。
+- 监控：新增异步 SQL tracing 指标。
+
+## 交付物
+- 重构后的数据库连接初始化（在现有位置原地改造为异步，使用 psycopg3）。
+- 学生模块（controller + service）端到端异步，接口不变。
+- 文档：运行手册与参数说明（连接池、超时）。
+
+## 验收标准
+- 功能：现有 API 行为、返回结构、错误码完全一致（回归全部通过）。
+- 架构：控制器不再使用 `run_in_threadpool`，Service 改为异步，并通过 `AsyncSession` 访问数据库。
+- 代码质量：无阻塞点混入（禁止在异步路径中调用同步 DB）；lint/typecheck 通过。


### PR DESCRIPTION
## Summary
Migrate students module to async database access with psycopg_async driver.

## Changes
- Replace synchronous Session with AsyncSession in students module
- Remove run_in_threadpool wrappers from controller layer
- Implement async endpoints and service methods (list_students, create_student)
- Update tests to use pytest-asyncio and AsyncClient
- Add async database utilities (get_async_db, AsyncDbSession, AsyncSessionLocal)
- Add psycopg_async and aiosqlite dependencies for async DB support
- Maintain API contract and business logic compatibility

## Migration Strategy
- Gradual migration: only students module is async-enabled in this PR
- Other modules continue using sync DB access until migrated
- Directly refactor existing code without creating parallel implementations
- Maintain identical API contracts and error codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migrated student module database layer to native asynchronous operations for enhanced request concurrency handling and improved performance.

* **Chores**
  * Updated all test infrastructure with asynchronous-capable fixtures and HTTP client utilities.
  * Added pytest-asyncio and aiosqlite as new dependencies for comprehensive async testing support.
  * Added detailed architecture documentation for async database refactoring specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->