### PR TITLE
feat(web): implement user registration with email verification using OTP

### DIFF
--- a/api/services/email_verification_service.py
+++ b/api/services/email_verification_service.py
@@ -61,7 +61,7 @@ class EmailVerificationService:
         digits = []
         for _ in range(length):
             # 生成一个 0-9 的数字
-            value = ord(os.urandom(1)) % 10
+            value = os.urandom(1)[0] % 10
             digits.append(str(value))
         return "".join(digits)
 

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { useTranslations } from "next-intl";
@@ -9,79 +10,93 @@ import { login, type LoginPayload } from "@/service/auth";
 import { setAccessToken } from "@/lib/auth";
 
 export default function LoginPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const t = useTranslations();
-  const {
-    register,
-    handleSubmit,
-    formState: { errors, isSubmitting },
-  } = useForm<LoginPayload>({ defaultValues: { username: "", password: "" } });
+   const router = useRouter();
+   const searchParams = useSearchParams();
+   const t = useTranslations();
+   const {
+     register,
+     handleSubmit,
+     formState: { errors, isSubmitting },
+   } = useForm<LoginPayload>({ defaultValues: { username: "", password: "" } });
 
-  const [errorMsg, setErrorMsg] = useState<string>("");
+   const [errorMsg, setErrorMsg] = useState<string>("");
 
+   const onSubmit = handleSubmit(async (values) => {
+     setErrorMsg("");
+     const res = await login(values);
+     if (res.code === 0 && res.data?.access_token) {
+       setAccessToken(res.data.access_token);
+       const raw = searchParams.get("next");
+       const nextPath =
+         raw && raw.startsWith("/") && !raw.startsWith("//") && !raw.includes("://")
+           ? raw
+           : "/";
+       router.replace(nextPath);
+     } else {
+       setErrorMsg(res.message || t("auth.login.error"));
+     }
+   });
 
-  const onSubmit = handleSubmit(async (values) => {
-    setErrorMsg("");
-    const res = await login(values);
-    if (res.code === 0 && res.data?.access_token) {
-      setAccessToken(res.data.access_token);
-      const raw = searchParams.get("next");
-      const nextPath =
-        raw && raw.startsWith("/") && !raw.startsWith("//") && !raw.includes("://")
-          ? raw
-          : "/";
-      router.replace(nextPath);
-    } else {
-      setErrorMsg(res.message || t("auth.login.error"));
-    }
-  });
+   return (
+     <div className="mx-auto flex min-h-[60vh] max-w-sm flex-col justify-center px-4 py-10">
+       <h1 className="mb-6 text-center text-2xl font-semibold">
+         {t("auth.login.title")}
+       </h1>
 
-  return (
-    <div className="mx-auto flex min-h-[60vh] max-w-sm flex-col justify-center px-4 py-10">
-      <h1 className="mb-6 text-center text-2xl font-semibold">{t("auth.login.title")}</h1>
+       <form onSubmit={onSubmit} className="space-y-4">
+         <div className="space-y-2">
+           <label htmlFor="username" className="block text-sm font-medium">
+             {t("auth.login.username")}
+           </label>
+           <input
+             id="username"
+             type="text"
+             className="w-full rounded-md border px-3 py-2 outline-none"
+             {...register("username", {
+               required: t("auth.login.errors.usernameRequired"),
+             })}
+           />
+           {errors.username?.message ? (
+             <p className="text-xs text-red-500">{errors.username.message}</p>
+           ) : null}
+         </div>
 
-      <form onSubmit={onSubmit} className="space-y-4">
-        <div className="space-y-2">
-          <label htmlFor="username" className="block text-sm font-medium">
-            {t("auth.login.username")}
-          </label>
-          <input
-            id="username"
-            type="text"
-            className="w-full rounded-md border px-3 py-2 outline-none"
-            {...register("username", { required: t("auth.login.errors.usernameRequired") })}
-          />
-          {errors.username?.message ? (
-            <p className="text-xs text-red-500">{errors.username.message}</p>
-          ) : null}
-        </div>
+         <div className="space-y-2">
+           <label htmlFor="password" className="block text-sm font-medium">
+             {t("auth.login.password")}
+           </label>
+           <input
+             id="password"
+             type="password"
+             className="w-full rounded-md border px-3 py-2 outline-none"
+             {...register("password", {
+               required: t("auth.login.errors.passwordRequired"),
+             })}
+           />
+           {errors.password?.message ? (
+             <p className="text-xs text-red-500">{errors.password.message}</p>
+           ) : null}
+         </div>
 
-        <div className="space-y-2">
-          <label htmlFor="password" className="block text-sm font-medium">
-            {t("auth.login.password")}
-          </label>
-          <input
-            id="password"
-            type="password"
-            className="w-full rounded-md border px-3 py-2 outline-none"
-            {...register("password", { required: t("auth.login.errors.passwordRequired") })}
-          />
-          {errors.password?.message ? (
-            <p className="text-xs text-red-500">{errors.password.message}</p>
-          ) : null}
-        </div>
+         {errorMsg ? (
+           <div className="text-sm text-red-600">{errorMsg}</div>
+         ) : null}
 
-        {errorMsg ? <div className="text-sm text-red-600">{errorMsg}</div> : null}
+         <button
+           type="submit"
+           disabled={isSubmitting}
+           className="w-full rounded-md bg-black px-4 py-2 text-white disabled:opacity-60"
+         >
+           {isSubmitting ? t("auth.login.submitting") : t("auth.login.submit")}
+         </button>
+       </form>
 
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="w-full rounded-md bg-black px-4 py-2 text-white disabled:opacity-60"
-        >
-          {isSubmitting ? t("auth.login.submitting") : t("auth.login.submit")}
-        </button>
-      </form>
-    </div>
-  );
-}
+       <p className="mt-4 text-center text-sm text-gray-600">
+         {t("auth.login.noAccount")}{" "}
+         <Link href="/register" className="text-blue-600 hover:underline">
+           {t("auth.login.goRegister")}
+         </Link>
+       </p>
+     </div>
+   );
+ }

--- a/web/src/app/register/page.tsx
+++ b/web/src/app/register/page.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { useTranslations } from "next-intl";
+
+import {
+  sendRegisterCode,
+  verifyAndCreate,
+  type VerifyAndCreatePayload,
+} from "@/service/auth";
+import { setAccessToken } from "@/lib/auth";
+import { withToast } from "@/lib/withToast";
+
+type RegisterFormValues = {
+  email: string;
+  code: string;
+  password: string;
+  confirmPassword: string;
+};
+
+export default function RegisterPage() {
+  const t = useTranslations();
+  const router = useRouter();
+  const [isSendingCode, setIsSendingCode] = useState(false);
+  const [cooldown, setCooldown] = useState(0);
+  const [errorMsg, setErrorMsg] = useState<string>("");
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<RegisterFormValues>({
+    defaultValues: {
+      email: "",
+      code: "",
+      password: "",
+      confirmPassword: "",
+    },
+  });
+
+  const watchedEmail = watch("email");
+
+  useEffect(() => {
+    if (cooldown <= 0) return;
+    const timer = setTimeout(() => setCooldown((prev) => prev - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [cooldown]);
+
+  const handleSendCode = async () => {
+    setErrorMsg("");
+    if (!watchedEmail) {
+      setErrorMsg(t("auth.register.errors.emailRequired"));
+      return;
+    }
+    if (cooldown > 0 || isSendingCode) {
+      return;
+    }
+
+    setIsSendingCode(true);
+    try {
+      await withToast(
+        (async () => {
+          const res = await sendRegisterCode({ email: watchedEmail });
+          if (res.code !== 0) {
+            throw new Error(res.message || "Request failed");
+          }
+          return res;
+        })(),
+        {
+          success: t("auth.register.toast.sendCodeSuccess"),
+          error: t("auth.register.toast.sendCodeFail"),
+        }
+      );
+      setCooldown(30);
+    } catch (e: unknown) {
+      const msg =
+        (e instanceof Error && e.message) || t("auth.register.errorNetwork");
+      setErrorMsg(msg);
+    } finally {
+      setIsSendingCode(false);
+    }
+  };
+
+  const onSubmit = handleSubmit(async (values) => {
+    setErrorMsg("");
+
+    if (values.password !== values.confirmPassword) {
+      setErrorMsg(t("auth.register.errors.passwordNotMatch"));
+      return;
+    }
+
+    const payload: VerifyAndCreatePayload = {
+      email: values.email,
+      code: values.code,
+      password: values.password,
+    };
+
+    try {
+      const res = await withToast(
+        (async () => {
+          const res = await verifyAndCreate(payload);
+          if (res.code !== 0 || !res.data?.access_token) {
+            throw new Error(res.message || t("auth.register.errorGeneric"));
+          }
+          return res;
+        })(),
+        {
+          success: t("auth.register.toast.registerSuccess"),
+          error: t("auth.register.toast.registerFail"),
+        }
+      );
+      // 经过上面的校验，这里可以安全访问 access_token
+      if (res.data?.access_token) {
+        setAccessToken(res.data.access_token);
+      }
+      router.replace("/students");
+    } catch (e: unknown) {
+      const msg =
+        (e instanceof Error && e.message) || t("auth.register.errorNetwork");
+      setErrorMsg(msg);
+    }
+  });
+
+  return (
+    <div className="mx-auto flex min-h-[60vh] max-w-sm flex-col justify-center px-4 py-10">
+      <h1 className="mb-6 text-center text-2xl font-semibold">
+        {t("auth.register.title")}
+      </h1>
+
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <label htmlFor="email" className="block text-sm font-medium">
+            {t("auth.register.email")}
+          </label>
+          <input
+            id="email"
+            type="email"
+            className="w-full rounded-md border px-3 py-2 outline-none"
+            {...register("email", {
+              required: t("auth.register.errors.emailRequired"),
+            })}
+          />
+          {errors.email?.message ? (
+            <p className="text-xs text-red-500">{errors.email.message}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="code" className="block text-sm font-medium">
+            {t("auth.register.code")}
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="code"
+              type="text"
+              className="flex-1 rounded-md border px-3 py-2 outline-none"
+              {...register("code", {
+                required: t("auth.register.errors.codeRequired"),
+              })}
+            />
+            <button
+              type="button"
+              onClick={handleSendCode}
+              disabled={isSendingCode || cooldown > 0}
+              className="whitespace-nowrap rounded-md border border-black px-3 py-2 text-sm font-medium disabled:opacity-60"
+            >
+              {cooldown > 0
+                ? `${t("auth.register.sendCode")} (${cooldown}s)`
+                : isSendingCode
+                  ? t("auth.register.sendingCode")
+                  : t("auth.register.sendCode")}
+            </button>
+          </div>
+          {errors.code?.message ? (
+            <p className="text-xs text-red-500">{errors.code.message}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="password" className="block text-sm font-medium">
+            {t("auth.register.password")}
+          </label>
+          <input
+            id="password"
+            type="password"
+            className="w-full rounded-md border px-3 py-2 outline-none"
+            {...register("password", {
+              required: t("auth.register.errors.passwordRequired"),
+            })}
+          />
+          {errors.password?.message ? (
+            <p className="text-xs text-red-500">{errors.password.message}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="confirmPassword" className="block text-sm font-medium">
+            {t("auth.register.confirmPassword")}
+          </label>
+          <input
+            id="confirmPassword"
+            type="password"
+            className="w-full rounded-md border px-3 py-2 outline-none"
+            {...register("confirmPassword", {
+              required: t("auth.register.errors.confirmPasswordRequired"),
+            })}
+          />
+          {errors.confirmPassword?.message ? (
+            <p className="text-xs text-red-500">
+              {errors.confirmPassword.message}
+            </p>
+          ) : null}
+        </div>
+
+        {errorMsg ? (
+          <div className="text-sm text-red-600">{errorMsg}</div>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full rounded-md bg-black px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+        >
+          {isSubmitting
+            ? t("auth.register.submitting")
+            : t("auth.register.submit")}
+        </button>
+      </form>
+
+      <p className="mt-4 text-center text-sm text-gray-600">
+        {t("auth.register.haveAccount")}{" "}
+        <Link href="/login" className="text-blue-600 hover:underline">
+          {t("auth.register.goLogin")}
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/web/src/i18n/messages/en/auth.json
+++ b/web/src/i18n/messages/en/auth.json
@@ -10,6 +10,36 @@
       "errors": {
         "usernameRequired": "Username is required",
         "passwordRequired": "Password is required"
+      },
+      "noAccount": "Don't have an account?",
+      "goRegister": "Sign up"
+    },
+    "register": {
+      "title": "Sign up",
+      "email": "Email",
+      "code": "Verification code",
+      "password": "Password",
+      "confirmPassword": "Confirm password",
+      "sendCode": "Send code",
+      "sendingCode": "Sending...",
+      "submit": "Complete registration",
+      "submitting": "Submitting...",
+      "errors": {
+        "emailRequired": "Email is required",
+        "codeRequired": "Verification code is required",
+        "passwordRequired": "Password is required",
+        "confirmPasswordRequired": "Confirm password is required",
+        "passwordNotMatch": "Passwords do not match"
+      },
+      "errorGeneric": "Registration failed, please try again later",
+      "errorNetwork": "Network error, please check your connection",
+      "haveAccount": "Already have an account?",
+      "goLogin": "Sign in",
+      "toast": {
+        "sendCodeSuccess": "Verification code has been sent, please check your email",
+        "sendCodeFail": "Failed to send verification code",
+        "registerSuccess": "Registration successful, redirecting...",
+        "registerFail": "Registration failed"
       }
     },
     "logout": {

--- a/web/src/i18n/messages/zh/auth.json
+++ b/web/src/i18n/messages/zh/auth.json
@@ -10,6 +10,36 @@
       "errors": {
         "usernameRequired": "用户名为必填项",
         "passwordRequired": "密码为必填项"
+      },
+      "noAccount": "还没有账号？",
+      "goRegister": "去注册"
+    },
+    "register": {
+      "title": "注册",
+      "email": "邮箱",
+      "code": "验证码",
+      "password": "密码",
+      "confirmPassword": "确认密码",
+      "sendCode": "发送验证码",
+      "sendingCode": "发送中...",
+      "submit": "完成注册",
+      "submitting": "提交中...",
+      "errors": {
+        "emailRequired": "邮箱为必填项",
+        "codeRequired": "验证码为必填项",
+        "passwordRequired": "密码为必填项",
+        "confirmPasswordRequired": "确认密码为必填项",
+        "passwordNotMatch": "两次输入的密码不一致"
+      },
+      "errorGeneric": "注册失败，请稍后重试",
+      "errorNetwork": "网络错误，请检查网络连接",
+      "haveAccount": "已有账号？",
+      "goLogin": "去登录",
+      "toast": {
+        "sendCodeSuccess": "验证码已发送，请查收邮箱",
+        "sendCodeFail": "验证码发送失败",
+        "registerSuccess": "注册成功，正在为你跳转",
+        "registerFail": "注册失败"
       }
     },
     "logout": {

--- a/web/src/service/auth.ts
+++ b/web/src/service/auth.ts
@@ -21,3 +21,38 @@ export type LogoutResponse = ApiResponse<null>;
 export async function logout(): Promise<LogoutResponse> {
   return httpPost<null>("/auth/logout", undefined, { credentials: "include" });
 }
+
+// ===== Registration (email + OTP) =====
+
+export type SendRegisterCodePayload = {
+  email: string;
+};
+
+export type SendRegisterCodeResponse = ApiResponse<null>;
+
+export async function sendRegisterCode(
+  payload: SendRegisterCodePayload
+): Promise<SendRegisterCodeResponse> {
+  return httpPost<null>("/auth/register/send-code", payload, { credentials: "include" });
+}
+
+export type VerifyAndCreatePayload = {
+  email: string;
+  code: string;
+  password: string;
+};
+
+export type VerifyAndCreateData = {
+  access_token: string;
+  refresh_expires_at?: number;
+};
+
+export type VerifyAndCreateResponse = ApiResponse<VerifyAndCreateData>;
+
+export async function verifyAndCreate(
+  payload: VerifyAndCreatePayload
+): Promise<VerifyAndCreateResponse> {
+  return httpPost<VerifyAndCreateData>("/auth/register/verify-and-create", payload, {
+    credentials: "include",
+  });
+}


### PR DESCRIPTION
## Summary

This PR implements a complete user registration flow with email verification using OTP (One-Time Password).

## Changes

- **Added registration page** (`/register` route) with email verification
- **Authentication service updates**:
  - Added `sendRegisterCode()` for sending OTP via email
  - Added `verifyAndCreate()` for completing registration with OTP verification
- **Login page improvements**:
  - Added link to registration page ("Don't have an account? Sign up")
- **Internationalization**:
  - Added EN/ZH translations for registration flow
  - Added success/error messages for OTP operations
- **Backend service enhancement**:
  - Improved OTP generation in `email_verification_service.py` for better reliability

## Features

✅ Email-based registration with OTP verification
✅ Resend OTP functionality
✅ Password confirmation validation
✅ Error handling and user feedback
✅ Navigation between login and registration pages
✅ Full i18n support (English/Chinese)

## Screenshots

*Login page with registration link:*
```
[Don't have an account? Sign up]
```

*New registration page:*
- Email input field
- Send verification code button  
- OTP code input
- Password and confirm password fields
- Submit registration button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed email verification code generation process.

* **New Features**
  * Redesigned login page with enhanced form validation, field-level error messages, and registration link for new users.
  * Launched new registration page featuring email-based code verification, password confirmation validation, and seamless account creation.
  * Added multi-language support for authentication screens and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->