### PR TITLE
feat(web): 添加认证令牌localStorage持久化存储

### DIFF
--- a/web/src/service/http.ts
+++ b/web/src/service/http.ts
@@ -111,7 +111,7 @@ async function requestWithAutoRefresh<T>(
       if (typeof window !== "undefined") {
         const loginUrl = "/login";
         try {
-          window.location.replace(loginUrl);
+          window.location.assign(loginUrl); // 使用 assign 以便历史可回退
         } catch {
           window.location.href = loginUrl;
         }


### PR DESCRIPTION
## 变更内容
- 在auth.ts中添加localStorage持久化存储认证令牌的功能
- 将http.ts中的location.replace改为location.assign以便历史可回退

## 主要改进
1. 认证状态现在会在页面刷新后保持，提升用户体验
2. 使用assign代替replace允许用户在登录页使用浏览器的后退按钮

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Access tokens are now persisted in local browser storage.

* **Bug Fixes**
  * Navigation after authentication redirects now supports browser history functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->