### PR TITLE
chore(web): 升级开发依赖版本

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -38,11 +38,11 @@
         "baseline-browser-mapping": "^2.9.11",
         "eslint": "^9",
         "eslint-config-next": "16.0.1",
-        "happy-dom": "^18.0.1",
+        "happy-dom": "^20.0.11",
         "msw": "^2.11.1",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5",
+        "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       }
     },
@@ -6416,9 +6416,9 @@
       }
     },
     "node_modules/happy-dom": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmmirror.com/happy-dom/-/happy-dom-18.0.1.tgz",
-      "integrity": "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==",
+      "version": "20.0.11",
+      "resolved": "https://registry.npmmirror.com/happy-dom/-/happy-dom-20.0.11.tgz",
+      "integrity": "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9748,9 +9748,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/web/package.json
+++ b/web/package.json
@@ -42,11 +42,11 @@
     "baseline-browser-mapping": "^2.9.11",
     "eslint": "^9",
     "eslint-config-next": "16.0.1",
-    "happy-dom": "^18.0.1",
+    "happy-dom": "^20.0.11",
     "msw": "^2.11.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5",
+    "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
## 概要
升级前端开发依赖以获得最新的功能和安全更新

## 主要变更

### 依赖升级
- **happy-dom**: `18.0.1` → `20.0.11`
  - 轻量级 DOM 实现库的主要版本升级
  - 可能包含性能改进和 API 更新
  
- **typescript**: `^5` → `^5.9.3`
  - 明确指定 TypeScript 版本为 5.9.3
  - 确保类型检查的一致性

## 影响范围
- 主要影响开发环境和测试运行
- happy-dom 用于组件测试环境
- typescript 用于类型检查

## 测试计划
- [ ] 运行 `npm run test` 确保测试通过
- [ ] 运行 `npm run lint` 确保类型检查通过
- [ ] 运行 `npm run build` 确保构建成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to their latest versions for improved stability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->