### PR TITLE
feat(api): 添加默认管理员账号初始化功能

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## 项目结构与模块组织
 - `api/` 为 FastAPI 后端，`controllers/` 存放路由控制器，`services/` 处理业务逻辑，`models/` 为 SQLAlchemy 模型，`schemas/` 为 Pydantic 模型，`tests/` 为 pytest 测试。迁移文件在 `api/migrations/`。
 - `web/` 为 Next.js 应用，App Router 在 `web/src/app/`，共享工具在 `web/src/lib/`，API 封装在 `web/src/service/`。
-- `docker/` 包含 `docker-compose.yaml`、服务脚本与挂载配置，例如 `docker/volumes/api/.env`。
+- `docker/` 包含 `docker-compose.yaml`、服务脚本与挂载配置，例如 `.env` 与 `api/.env.example`。
 - `spec/` 存放前端与编码规范相关的说明文档。
 
 ## 构建、测试与开发命令
@@ -37,7 +37,7 @@ Docker：
 - PR 需要清晰描述，相关问题请关联链接；涉及 UI 变更请附截图；如有迁移或环境改动请注明。
 
 ## 配置与安全建议
-- 后端配置通过环境变量加载，示例见 `docker/volumes/api/.env`。
+- 后端配置通过环境变量加载，示例见 `api/.env.example`。
 - 避免提交密钥，使用本地 `.env` 或 CI secrets。
 
 ## 重要，必须遵守的规则

--- a/api/.env.example
+++ b/api/.env.example
@@ -11,6 +11,14 @@ DOCS_USERNAME=fastapi-nextjs
 DOCS_PASSWORD=fastapi-nextjs-docs
 
 # =============================
+# 默认管理员初始化
+# =============================
+# 默认管理员用户名
+DEFAULT_ADMIN_USERNAME=admin
+# 默认管理员密码
+DEFAULT_ADMIN_PASSWORD=change-me
+
+# =============================
 # 数据库（PostgreSQL）连接
 # =============================
 # 数据库用户名

--- a/api/bin/boot.sh
+++ b/api/bin/boot.sh
@@ -5,12 +5,18 @@ HOST=${HOST:-"0.0.0.0"}
 PORT=${PORT:-8000}
 WORKERS=${WORKERS:-1}
 MIGRATION_ENABLED=${MIGRATION_ENABLED:-"false"}
+INIT_ADMIN_ENABLED=${INIT_ADMIN_ENABLED:-"false"}
 
 if [[ "${MIGRATION_ENABLED}" == "true" ]]; then
   echo "Running migrations"
   pushd "$(dirname "$0")/../migrations" > /dev/null
   alembic upgrade head
   popd > /dev/null
+fi
+
+if [[ "${INIT_ADMIN_ENABLED}" == "true" ]]; then
+  echo "Initializing default admin user"
+  (cd "$(dirname "$0")/.." && python -m utils.seed_users)
 fi
 
 echo "fastapi run on $HOST:$PORT with $WORKERS workers"

--- a/api/tests/unit_tests/test_seed_users.py
+++ b/api/tests/unit_tests/test_seed_users.py
@@ -6,15 +6,10 @@ from core.security import verify_password
 from models.users import User
 
 
-async def _async_upsert_user(
+async def _async_create_user_if_missing(
     async_db_session: AsyncSession, username: str, plain_password: str, role: str
 ) -> tuple[User, str]:
-    """异步包装 upsert_user，用于测试。
-
-    由于 upsert_user 本身是同步的（用于 CLI 脚本），我们使用 run_sync 在异步上下文中调用。
-    """
-    # 使用 connection 的 run_sync 来执行同步 ORM 操作
-    # 但更简单的方式是直接在异步 session 中重新实现逻辑
+    """异步实现 create_user_if_missing，用于测试。"""
     result = await async_db_session.execute(select(User).filter_by(username=username))
     user = result.scalar_one_or_none()
 
@@ -31,29 +26,13 @@ async def _async_upsert_user(
         async_db_session.add(user)
         return user, "created"
 
-    need_update = False
-
-    if user.role != role:
-        user.role = role
-        need_update = True
-
-    if not verify_password(plain_password, user.password_hash):
-        from core.security import hash_password
-
-        user.password_hash = hash_password(plain_password)
-        need_update = True
-
-    if not user.is_active:
-        user.is_active = True
-        need_update = True
-
-    return user, ("updated" if need_update else "skipped")
+    return user, "skipped"
 
 
 @pytest.mark.asyncio
 async def test_seed_creates_admin_and_user(async_db_session: AsyncSession):
-    user_admin, action_admin = await _async_upsert_user(async_db_session, "admin", "123456", "admin")
-    user_user, action_user = await _async_upsert_user(async_db_session, "user", "123456", "user")
+    user_admin, action_admin = await _async_create_user_if_missing(async_db_session, "admin", "123456", "admin")
+    user_user, action_user = await _async_create_user_if_missing(async_db_session, "user", "123456", "user")
     await async_db_session.commit()
 
     assert action_admin == "created"
@@ -74,18 +53,15 @@ async def test_seed_creates_admin_and_user(async_db_session: AsyncSession):
 
 @pytest.mark.asyncio
 async def test_seed_idempotent_skips_when_no_change(async_db_session: AsyncSession):
-    """
-    Verifies that calling upsert_user again with identical username, password, and role
-    is idempotent and preserves the stored password hash.
-    """
-    await _async_upsert_user(async_db_session, "admin", "123456", "admin")
+    """重复初始化时跳过，不更新密码。"""
+    await _async_create_user_if_missing(async_db_session, "admin", "123456", "admin")
     await async_db_session.commit()
 
     result_before = await async_db_session.execute(select(User).where(User.username == "admin"))
     before = result_before.scalar_one()
     hash_before = before.password_hash
 
-    _, action = await _async_upsert_user(async_db_session, "admin", "123456", "admin")
+    _, action = await _async_create_user_if_missing(async_db_session, "admin", "123456", "admin")
     await async_db_session.commit()
 
     result_after = await async_db_session.execute(select(User).where(User.username == "admin"))
@@ -95,14 +71,15 @@ async def test_seed_idempotent_skips_when_no_change(async_db_session: AsyncSessi
 
 
 @pytest.mark.asyncio
-async def test_seed_updates_role(async_db_session: AsyncSession):
-    await _async_upsert_user(async_db_session, "bob", "123456", "user")
+async def test_seed_skip_does_not_update_existing_user(async_db_session: AsyncSession):
+    await _async_create_user_if_missing(async_db_session, "bob", "123456", "user")
     await async_db_session.commit()
 
-    _, action = await _async_upsert_user(async_db_session, "bob", "123456", "admin")
+    _, action = await _async_create_user_if_missing(async_db_session, "bob", "newpass", "admin")
     await async_db_session.commit()
 
     result = await async_db_session.execute(select(User).where(User.username == "bob"))
     got = result.scalar_one()
-    assert action == "updated"
-    assert got.role == "admin"
+    assert action == "skipped"
+    assert got.role == "user"
+    assert verify_password("123456", got.password_hash) is True

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
       - PORT=8000
       - WORKERS=1
       - MIGRATION_ENABLED=true
+      - INIT_ADMIN_ENABLED=true
     depends_on:
       - postgres
       - redis

--- a/spec/default-admin.md
+++ b/spec/default-admin.md
@@ -1,0 +1,36 @@
+# 默认管理员账号初始化需求文档
+
+## 需求描述
+项目初始化时需要自动创建一个默认的管理员账号与密码，确保系统在首次部署/启动后即可登录后台进行基础配置与管理。同时需要避免重复创建以及不必要的明文密码持久化风险。
+
+## 需求目标
+- 在项目初始化阶段自动创建默认管理员账号。
+- 默认管理员账号只创建一次；若已存在同名管理员账号则不更新密码。
+- 管理员账号与密码通过环境变量配置，避免写死在代码中。
+- 初始化逻辑由独立开关控制，便于不同环境选择是否执行。
+- 记录必要的初始化结果（成功/已存在/失败），便于排查。
+
+## 技术方案
+- 在启动脚本中读取环境变量并触发初始化逻辑。
+- 环境变量：
+  - `DEFAULT_ADMIN_USERNAME`
+  - `DEFAULT_ADMIN_PASSWORD`
+  - `INIT_ADMIN_ENABLED`（独立开关，`true` 时执行初始化，默认 `false`）
+- 初始化逻辑：
+  - 查询用户表是否已存在同名账号；若存在则跳过，不更新密码。
+  - 若不存在，使用安全哈希写入数据库，角色设置为 `admin`，`is_active` 为 `true`。
+- 日志中不输出完整密码，仅提示已读取配置。
+- 初始化脚本可参考现有 `api/utils/seed_users.py`（可复用哈希与用户创建逻辑，保持“仅创建不更新密码”的行为）。
+- `api/utils/seed_users.py` 提供 `create_user_if_missing`，仅创建用户并在已存在时直接跳过。
+
+## 已实现改动（同步记录）
+- 启动脚本：`api/bin/boot.sh` 在 `INIT_ADMIN_ENABLED=true` 时执行 `python -m utils.seed_users`，失败会阻断启动。
+- 初始化脚本：`api/utils/seed_users.py` 仅支持从环境变量创建默认管理员，不再包含 dev/test 默认账号逻辑。
+- 用户创建函数：将 `upsert_user` 重命名为 `create_user_if_missing`，只创建不更新。
+- Docker Compose：`docker/docker-compose.yaml` 的 `api` 服务加入 `INIT_ADMIN_ENABLED`。
+- 环境变量示例：`api/.env.example` 增加 `DEFAULT_ADMIN_USERNAME`、`DEFAULT_ADMIN_PASSWORD`。
+- 测试用例：`api/tests/unit_tests/test_seed_users.py` 调整为“只创建、已存在跳过”语义。
+
+## 待讨论事项
+- 初始化失败时应阻断启动（明确要求）。
+- 生产环境不强制设置 `INIT_ADMIN_ENABLED=true`（明确要求）。


### PR DESCRIPTION
## 功能概述
添加通过环境变量配置的默认管理员账号初始化功能，支持在容器启动时自动创建管理员账号。

## 主要改动
- `api/bin/boot.sh`: 新增 `INIT_ADMIN_ENABLED` 环境变量控制是否执行初始化
- `api/utils/seed_users.py`: 重构为仅创建不更新语义，从环境变量读取管理员配置
- `api/.env.example`: 新增 `DEFAULT_ADMIN_USERNAME` 和 `DEFAULT_ADMIN_PASSWORD` 配置项
- `docker/docker-compose.yaml`: api 服务添加 `INIT_ADMIN_ENABLED=true` 环境变量
- `api/tests/unit_tests/test_seed_users.py`: 更新测试用例适配新的仅创建语义
- `spec/default-admin.md`: 添加默认管理员初始化需求文档
- `AGENTS.md`: 更新配置文件路径说明

## 特性
- **仅创建不更新**: 若管理员账号已存在则跳过，不覆盖密码
- **环境变量配置**: 管理员用户名和密码通过环境变量配置
- **独立开关控制**: `INIT_ADMIN_ENABLED` 控制是否执行初始化，默认为 false
- **失败阻断**: 初始化失败时会阻止容器启动

## 测试计划
- [x] 单元测试通过
- [ ] 本地容器启动验证
- [ ] 生产环境部署验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic default administrator account initialization during startup when enabled via environment variable
  * Configurable admin credentials through environment variables
  * Idempotent admin creation—existing accounts remain unchanged

* **Documentation**
  * Added admin initialization setup guide and requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->